### PR TITLE
Bump SNNModels compat to 1.8 (v0.2.7)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SNNUtils"
 uuid = "df079cdf-2344-43fe-90b5-fc41d8d26db7"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["alequa <alessio.quaresima@pasteur.fr>"]
 
 [deps]
@@ -62,7 +62,7 @@ Parameters = "0.12"
 Printf = "1.11"
 Random = "1.11"
 Requires = "1.3"
-SNNModels = "1.5"
+SNNModels = "1.8"
 ScientificTypes = "3.1.1"
 Serialization = "1.11"
 StatisticalMeasures = "0.1, 0.3"


### PR DESCRIPTION
## Summary
- Bump `SNNModels` compat bound from 1.5 to 1.8
- Patch version 0.2.6 → 0.2.7

@JuliaRegistrator register