### PR TITLE
version compatibility updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SNNUtils"
 uuid = "df079cdf-2344-43fe-90b5-fc41d8d26db7"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["alequa <alessio.quaresima@pasteur.fr>"]
 
 [deps]
@@ -70,4 +70,4 @@ Statistics = "1.11"
 StatsBase = "0.34"
 Tables = "1.12.1"
 ThreadTools = "0.2"
-julia = "1.10"
+julia = "1.12"


### PR DESCRIPTION
Bump julia compat 1.10 -> 1.12 and patch version 0.2.7 -> 0.2.8. SNNModels >=1.7 requires julia >=1.12 (per registry Compat.toml), so SNNUtils' own julia floor was stale and blocking AutoMerge on the v0.2.7 registration.